### PR TITLE
LockClock: Reset visibility for Weather Image when weather info is

### DIFF
--- a/src/com/cyanogenmod/lockclock/ClockWidgetService.java
+++ b/src/com/cyanogenmod/lockclock/ClockWidgetService.java
@@ -405,6 +405,7 @@ public class ClockWidgetService extends IntentService {
 
         // Weather Image
         int resId = w.getConditionResource(iconsSet);
+        weatherViews.setViewVisibility(R.id.weather_image, View.VISIBLE);
         if (resId != 0) {
             weatherViews.setImageViewResource(R.id.weather_image, w.getConditionResource(iconsSet));
         } else {


### PR DESCRIPTION
available

If weather info is unavailable the image visibility is set to INVISIBLE.
So we need to reset visibility when weather info is available.

Change-Id: I7d8c673a72bf71b3c397361167c2a8000194eb90